### PR TITLE
require symfony/yaml

### DIFF
--- a/phinx/Dockerfile
+++ b/phinx/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH /composer/vendor/bin:$PATH
 
 RUN docker-php-ext-install pdo_mysql
 RUN composer global require 'robmorgan/phinx'
+RUN composer global require 'symfony/yaml'
 
 ENTRYPOINT ["phinx"]
 CMD ["list"]


### PR DESCRIPTION
Somehow symphony/yaml was made an optional dev-dependency, which causes stuff to not work :( 
https://github.com/cakephp/phinx/issues/1726